### PR TITLE
Chance config URL to point to the true repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,7 +77,7 @@ navigation:
 repos:
 - name: Frontend Guides
   description: Main repository
-  url: https://github.com/18F/guides-template
+  url: https://github.com/18F/frontend
 
 # Style Variables
 brand_color: "#1188ff"

--- a/_config.yml
+++ b/_config.yml
@@ -75,7 +75,7 @@ navigation:
   internal: true
 
 repos:
-- name: Guides Template
+- name: Frontend Guides
   description: Main repository
   url: https://github.com/18F/guides-template
 


### PR DESCRIPTION
The bottom link on https://pages.18f.gov/frontend/index.html currently points at https://github.com/18F/guides-template/edit/18f-pages/index.md.
