### PR TITLE
Fix broken link in Inheritance.md

### DIFF
--- a/pages/css-styleguide/inheritance.md
+++ b/pages/css-styleguide/inheritance.md
@@ -27,7 +27,7 @@ parent: CSS coding styleguide
 }
 ```
 
-- Do not use mixins for browser prefixes. Use [Autoprefixer]https://github.com/postcss/autoprefixer).
+- Do not use mixins for browser prefixes. Use [Autoprefixer](https://github.com/postcss/autoprefixer).
 
 ```scss
 // Bad


### PR DESCRIPTION
Autoprefixer link didn't have an opening parenthesis.
