### PR TITLE
Standard .scss-lint.yml 

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,147 @@
+exclude: 'scss/lib/**'
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+  BorderZero:
+    enabled: false
+    convention: zero
+  ColorKeyword:
+    enabled: true
+    severity: warning
+  ColorVariable:
+    enabled: true
+  Comment:
+    enabled: true
+  DebugStatement:
+    enabled: true
+  DeclarationOrder:
+    enabled: false
+  DuplicateProperty:
+    enabled: true
+  ElsePlacement:
+    enabled: true
+    style: same_line
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+  EmptyRule:
+    enabled: true
+  FinalNewline:
+    enabled: true
+    present: true
+  HexLength:
+    enabled: false
+    style: short
+  HexNotation:
+    enabled: true
+    style: lowercase
+  HexValidation:
+    enabled: true
+  IdSelector:
+    enabled: true
+  ImportantRule:
+    enabled: true
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space
+    width: 2
+  LeadingZero:
+    enabled: false
+    style: include_zero
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+  NestingDepth:
+    enabled: true
+    max_depth: 4
+    severity: warning
+  PlaceholderInExtend:
+    enabled: false
+  PropertyCount:
+    enabled: true
+    include_nested: false
+    max_properties: 10
+  PropertySortOrder:
+    enabled: false
+    ignore_unspecified: false
+    severity: warning
+    separate_groups: false
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+    severity: warning
+  SelectorDepth:
+    enabled: true
+    max_depth: 2
+    severity: warning
+  SelectorFormat:
+    enabled: false # strict_BEM doesn't seem to be supported by Hound
+    convention: strict_BEM
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2]
+    severity: warning
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+  SingleLinePerSelector:
+    enabled: true
+  SpaceAfterComma:
+    enabled: true
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space
+  SpaceAfterPropertyName:
+    enabled: true
+  SpaceBeforeBrace:
+    enabled: true
+    style: space
+    allow_single_line_padding: false
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+  StringQuotes:
+    enabled: true
+    style: single_quotes
+  TrailingSemicolon:
+    enabled: true
+  TrailingZero:
+    enabled: false
+  UnnecessaryMantissa:
+    enabled: true
+  UnnecessaryParentReference:
+    enabled: true
+  UrlFormat:
+    enabled: true
+  UrlQuotes:
+    enabled: true
+  VariableForProperty:
+    enabled: false
+    properties: []
+  VendorPrefixes:
+    enabled: true
+    identifier_list: bourbon
+    include: []
+    exclude: []
+  ZeroUnit:
+    enabled: true
+    severity: warning
+  Compass::PropertyWithMixin:
+    enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,5 +1,3 @@
-exclude: 'scss/lib/**'
-
 linters:
   BangFormat:
     enabled: true

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ exclude:
 - LICENSE.md
 - README.md
 - go
+include:
+- .scss-lint.yml
 
 permalink: pretty
 highlighter: rouge

--- a/pages/css-styleguide/preprocessor.md
+++ b/pages/css-styleguide/preprocessor.md
@@ -6,6 +6,8 @@ parent: CSS coding styleguide
 
 The most supported CSS preprocessor at 18F is Sass/SCSS. Using this pre-processor means you'll get supported resources such as frameworks, libraries, tutorials, and a comprehensive styleguide as support.
 
+In addition, 18F uses a [`.scss-lint.yml` file]({{ '/.scss-lint.yml' | prepend: site_baseurl }}) to keep our CSS code compliant with our own styleguide.
+
 That being said, any preprocessor is allowed as long as it's a sound project and has community support.
 
 The recommended way to compile your Sass code is through [node-sass](https://www.npmjs.com/package/node-sass) (rather than Ruby Sass). This allows eliminating the dependency on Ruby for projects that don't already require it and is the fastest method of compiling Sass.


### PR DESCRIPTION
@noahmanger, @jmcarp and team are using `scss-lint` on [fec-style](github.com/18f/fec-style) and it seems to be working really well for them. Plus, they've got a really nifty hound integration set up to run the linter on every PR.

I propose this to fix #19 (at least for now) in favor of recommending the above set up for projects to use. I've shamelessly taken their `.scss-lint.yml` and included it in this repo and linked to it from the Preprocessor documentation.

I checked against our CSS styleguide to see where the `.scss-lint.yml` falls short and it gets us quite far right out of the box. As far as I can tell, here is where it doesn't enforce our current styleguide (though I'm pretty confident it can be customized to do so):
1. Does not limit line width to 80 characters
2. Does not numeric calculations in parentheses
3. Does not sort properties in quite the order we want (defaults to alphabetical)

The downside is that it makes Ruby a dependency to run the linter (though that is somewhat reduced by the Hound integration).

On the plus side, it does pretty much exactly what we want right out of the box :)
