### PR TITLE
Add purpose and linting instructions to home

### DIFF
--- a/pages/css-styleguide/css_coding_styleguide.md
+++ b/pages/css-styleguide/css_coding_styleguide.md
@@ -4,7 +4,7 @@ title: CSS coding styleguide
 ---
 
 ## Purpose
-The purpose of the css coding styleguide is to create consistent CSS or preproccessor CSS code across 18F. The styleguide should be treated as a guide, rules can be modified according to project needs.
+The purpose of the CSS coding styleguide is to create consistent CSS or preproccessor CSS code across 18F. The styleguide should be treated as a guide, rules can be modified according to project needs.
 
 ## Linting
 The styleguide provides a method of linting SASS code to ensure it conforms to the rules in the styleguide. This linting tool will go through all SASS code and issue warnings wherever the code differs from the styleguide. We've created a specific [`.scss-lint.yml` file]({{ '/.scss-lint.yml' | prepend: site_baseurl }}) that's configured to work with the css coding styleguide. There are two ways to setup linting, linting on github with Hound, or linting locally with ruby:

--- a/pages/css-styleguide/css_coding_styleguide.md
+++ b/pages/css-styleguide/css_coding_styleguide.md
@@ -2,3 +2,26 @@
 permalink: /css-coding-styleguide/
 title: CSS coding styleguide
 ---
+
+## Purpose
+The purpose of the css coding styleguide is to create consistent CSS or preproccessor CSS code across 18F. The styleguide should be treated as a guide, rules can be modified according to project needs.
+
+## Linting
+The styleguide provides a method of linting SASS code to ensure it conforms to the rules in the styleguide. This linting tool will go through all SASS code and issue warnings wherever the code differs from the styleguide. We've created a specific [`.scss-lint.yml` file]({{ '/.scss-lint.yml' | prepend: site_baseurl }}) that's configured to work with the css coding styleguide. There are two ways to setup linting, linting on github with Hound, or linting locally with ruby:
+
+### On Github with Hound
+1. Go to [Hound](https://houndci.com/).
+2. Sign in with Github.
+3. Activate the respository through [Hound](https://houndci.com/repos).
+4. Add the [`.scss-lint.yml` file]({{ '/.scss-lint.yml' | prepend: site_baseurl }}) to the base of your repository.
+
+### Locally with ruby
+1. Add the [`.scss-lint.yml` file]({{ '/.scss-lint.yml' | prepend: site_baseurl }}) to the base of your repository.
+2. Install the [sass-lint](https://github.com/brigade/scss-lint) gem: `gem install scss_lint`
+3. Run sass-link: `scss-lint app/assets/stylesheets/`
+
+### Shortcomings
+The scss-lint tool currently lacks the functionality to check these rules in the css coding styleguide:
+- Does not limit line width to 80 characters
+- Does not numeric calculations in parentheses
+- Does not sort properties in quite the order we want (defaults to alphabetical)


### PR DESCRIPTION
Adding a purpose statement and instructions on linting to the home page of the styleguide. This is to ensure any developer coming to the project has instructions on how to set everything up.
