### PR TITLE
Update Sass Order

### DIFF
--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -176,12 +176,12 @@ $align_top: 100%;
   margin-top: $amount * 1em;
   text-align: center;
 
-  .module__ele {
-    color: #fff932;
-  }
-
   @include media($sm) {
     margin-top: ($amount + 10em);
+  }
+  
+  .module__ele {
+    color: #fff932;
   }
 }
 ```

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -177,8 +177,12 @@ $align_top: 100%;
   margin-top: $amount * 1em;
   text-align: center;
 
-  @include media($small) {
+  @include media($small-screen) {
     margin-top: ($amount + 10em);
+  }
+
+  &::before {
+    content: "hello";
   }
 
   .module__ele {

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -141,16 +141,15 @@ $align_top: 100%;
   1. variables
   2. @extend directives
   3. @include directives
-  4. declaration list (properties)
+  4. declaration list (property name and value)
   5. media queries
   6. pseudo-states and pseudo-elements
   7. nested elements
   8. nested classes
 
-- Within properties, you may use alphabetical order or type order. Just pick one and keep the whole project consistent.
+- Use alphabetical order or type order for declarations. Pick one to keep the whole project consistent.
 - Put a new line before nested selectors unless they are after the first selector.
 - Put mixin calls with @content after nested selectors.
-- Properties should be alphabetical, not grouped by type or length.
 
 ```scss
 // Bad

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -136,7 +136,7 @@ $align_top: 100%;
 }
 ```
 
-## Sorting
+## Order
 * Follow ordering:
   1. variables
   2. @extend directives

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -152,7 +152,6 @@ $align_top: 100%;
 - Put mixin calls with @content after nested selectors.
 - Treat nested includes, such as Neat's media includes — `@include media($small-screen)` — as a standard media query, rather than a Sass @include. So they would be sorted directly after the declaration list.
 
-
 ```scss
 // Bad
 .module {

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -137,7 +137,7 @@ $align_top: 100%;
 ```
 
 ## Order
-* Follow ordering:
+* Use the following ordering:
   1. variables
   2. @extend directives
   3. @include directives
@@ -148,9 +148,10 @@ $align_top: 100%;
   8. nested classes
 
 - Use alphabetical order or type order for declarations. Pick one to keep the whole project consistent.
-- Put a new line before nested selectors unless they are after the first selector.
+- Place a new line before nested selectors unless they are after the first selector.
 - Treat nested includes, such as Neat's media includes — `@include media($small-screen)` — as a standard media query, rather than a Sass @include. So they would be sorted directly after the declaration list.
-- Put mixin calls with @content after nested selectors.
+- Place mixin calls with @content after nested selectors.
+- You may deviate the sorting order to better suit your project's needs, as long as it's consistent throughout the project.
 
 ```scss
 // Bad

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -177,7 +177,7 @@ $align_top: 100%;
   margin-top: $amount * 1em;
   text-align: center;
 
-  @include media($sm) {
+  @include media($small) {
     margin-top: ($amount + 10em);
   }
 

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -141,7 +141,12 @@ $align_top: 100%;
   1. variables
   2. @extend directives
   3. @include directives
-  4. properties
+  4. declaration list (properties)
+  5. media queries
+  6. pseudo-states and pseudo-elements
+  7. nested elements
+  8. nested classes
+
 - Within properties, you may use alphabetical order or type order. Just pick one and keep the whole project consistent.
 - Put a new line before nested selectors unless they are after the first selector.
 - Put mixin calls with @content after nested selectors.

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -149,8 +149,8 @@ $align_top: 100%;
 
 - Use alphabetical order or type order for declarations. Pick one to keep the whole project consistent.
 - Put a new line before nested selectors unless they are after the first selector.
-- Put mixin calls with @content after nested selectors.
 - Treat nested includes, such as Neat's media includes — `@include media($small-screen)` — as a standard media query, rather than a Sass @include. So they would be sorted directly after the declaration list.
+- Put mixin calls with @content after nested selectors.
 
 ```scss
 // Bad
@@ -179,7 +179,7 @@ $align_top: 100%;
   @include media($sm) {
     margin-top: ($amount + 10em);
   }
-  
+
   .module__ele {
     color: #fff932;
   }

--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -150,6 +150,8 @@ $align_top: 100%;
 - Use alphabetical order or type order for declarations. Pick one to keep the whole project consistent.
 - Put a new line before nested selectors unless they are after the first selector.
 - Put mixin calls with @content after nested selectors.
+- Treat nested includes, such as Neat's media includes — `@include media($small-screen)` — as a standard media query, rather than a Sass @include. So they would be sorted directly after the declaration list.
+
 
 ```scss
 // Bad


### PR DESCRIPTION
This updates the Sass order to reflect the order of additional items. This adds additional guidance based off of Thoughtbot's Sass styleguide, however does not include order of concatenated selectors because we do not recommend using them.

This also changes the heading title from "Sorting" to "Order" since it deals with what order properties should be in.

Resolves #65.
