### PR TITLE
Fix 'principle' usage

### DIFF
--- a/pages/recommended/intro.md
+++ b/pages/recommended/intro.md
@@ -5,8 +5,8 @@ title: Recommendations
 
 If you're building a web site or application from scratch, you're probably doing it wrong. There are an uncountable number of open source tools at your disposal, from ready-to-use style frameworks to expansive code libraries, that can help you get your job done more easily while also serving as a common ground for other designers and developers.
 
-## Principals
-The opinions in this guide attempt to reflect 18f's core development principals of:
+## Principles
+The opinions in this guide attempt to reflect 18f's core development principles of:
 
 - **Accessibility**, for users first, developers as well.
 - **Open source**, for transparency and contribution.


### PR DESCRIPTION
Use `principle`, meaning an idea, rather than `principal`, meaning first or senior.
