### PR TITLE
The shortcomings should include selector per line

### DIFF
--- a/pages/css-styleguide/css_coding_styleguide.md
+++ b/pages/css-styleguide/css_coding_styleguide.md
@@ -25,3 +25,4 @@ The scss-lint tool currently lacks the functionality to check these rules in the
 - Does not limit line width to 80 characters
 - Does not check for numeric calculations in parentheses
 - Does not sort properties in quite the order we want (defaults to alphabetical)
+- Does not allow setting the one selector per line rule based on how many characters the selector


### PR DESCRIPTION
Our guidelines say that each selector should be on a new line unless it's less then 5 characters. This cannot currently be enforced with scss-lint.

See https://github.com/18F/web-design-standards/pull/976#issuecomment-178163720 for reference.
