### PR TITLE
Collapse the nav by default

### DIFF
--- a/_includes/loop-nav.html
+++ b/_includes/loop-nav.html
@@ -3,9 +3,9 @@
   <a href="#{{ chapter.id }}">{{ chapter.title }}</a>
   {% if chapter.children %}
     <button class="expand-subnav"
-      aria-expanded="true"
+      aria-expanded="false"
       aria-controls="nav-collapsible-{{ chapter.id }}">+</button>
-    <ol class="nav-children" id="nav-collapsible-{{ chapter.id }}" aria-hidden="false">
+    <ol class="nav-children" id="nav-collapsible-{{ chapter.id }}" aria-hidden="true">
       {% include loop-nav.html chapters=chapter.children %}
     </ol>
   {% endif %}


### PR DESCRIPTION
:eyes: [preview on Federalist](https://federalist.18f.gov/preview/18F/frontend/collapse-nav/)

This inverts the default state of the nav so that nested nodes are collapsed by default. cc @xtine 
