### PR TITLE
Fix typo in format.md

### DIFF
--- a/pages/css-styleguide/format.md
+++ b/pages/css-styleguide/format.md
@@ -31,7 +31,7 @@ parent: CSS coding styleguide
 }
 ```
 
-- Multiple selectors should each be on a single line, with no space after each comma, unless they selector is less than five chars.
+- Multiple selectors should each be on a single line, with no space after each comma, unless the selector is less than five chars.
 
 ```scss
 // Bad


### PR DESCRIPTION
Replace "they selector" with "the selector."
