### PR TITLE
[WIP] Remove "technical guides" structure

### DIFF
--- a/_data/chapters.yml
+++ b/_data/chapters.yml
@@ -8,31 +8,25 @@
     - id: web-standards
     - id: style-guides
     - id: frameworks
-
-- id: technical
+- id: html
+- id: css
   children:
-    - id: html
+    - id: css-linting
+    - id: css-preprocessors
+    - id: css-frameworks
+    - id: css-formatting
+    - id: css-units
+    - id: css-naming
+    - id: css-inheritance
+    - id: css-architecture
+    - id: css-specificity
+    - id: css-variables
+    - id: css-documentation
+- id: javascript
+  children:
+    - id: js-dependencies
+    - id: js-libraries
+    - id: js-frameworks
 
-    - id: css
-      children:
-        - id: css-linting
-        - id: css-preprocessors
-        - id: css-frameworks
-        - id: css-formatting
-        - id: css-units
-        - id: css-naming
-        - id: css-inheritance
-        - id: css-architecture
-        - id: css-specificity
-        - id: css-variables
-        - id: css-documentation
-
-    - id: javascript
-      children:
-        - id: js-dependencies
-        - id: js-libraries
-        - id: js-frameworks
-
-    - id: web-components
-
+- id: web-components
 - id: contributing


### PR DESCRIPTION
This moves the HTML (disabled), CSS, and JS guides up into the root structure.
