### PR TITLE
[WIP] Update gem to use WDS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,50 +1,58 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    colorator (0.1)
-    ffi (1.9.10)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
     go_script (0.1.9)
       bundler (~> 1.10)
       safe_yaml (~> 1.0)
-    guides_style_18f (0.4.6)
+    guides_style_18f (1.0.0)
       jekyll
       jekyll_pages_api
       jekyll_pages_api_search
       rouge
       sass
     htmlentities (4.3.4)
-    jekyll (3.1.6)
-      colorator (~> 0.1)
+    jekyll (3.4.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
       liquid (~> 3.0)
       mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-sass-converter (1.4.0)
+    jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
-    jekyll-watch (1.4.0)
+    jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    jekyll_pages_api (0.1.5)
+    jekyll_pages_api (0.1.6)
       htmlentities (~> 4.3)
       jekyll (>= 2.0, < 4.0)
     jekyll_pages_api_search (0.4.4)
       jekyll_pages_api (~> 0.1.4)
       sass (~> 3.4)
-    kramdown (1.11.1)
+    kramdown (1.13.2)
     liquid (3.0.6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    rb-fsevent (0.9.7)
-    rb-inotify (0.9.7)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (2.0.5)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
-    rouge (1.10.1)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.22)
+    sass (3.4.23)
 
 PLATFORMS
   ruby
@@ -56,4 +64,4 @@ DEPENDENCIES
   redcarpet
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/_config.yml
+++ b/_config.yml
@@ -36,5 +36,5 @@ repos:
     url: https://github.com/18F/frontend
 
 back_link:
-  url: "https://pages.18f.gov/guides/"
+  url: "https://guides.18f.gov/guides"
   text: Read more 18F Guides

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,0 +1,32 @@
+<div class="usa-banner">
+  <div class="usa-accordion">
+    <header class="usa-banner-header">
+      <div class="usa-grid usa-banner-inner">
+      <img src="{{ site.baseurl }}/assets/uswds/img/favicons/favicon-57.png" alt="U.S. flag">
+      <p>An official website of the United States government</p>
+      <button class="usa-accordion-button usa-banner-button"
+        aria-expanded="false" aria-controls="gov-banner">
+        <span class="usa-banner-button-text">Here's how you know</span>
+      </button>
+      </div>
+    </header>
+    <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+      <div class="usa-banner-guidance-gov usa-width-one-half">
+        <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/uswds/img/icon-dot-gov.svg" alt="Dot gov">
+        <div class="usa-media_block-body">
+          <p>
+            <strong>The .gov means it’s official.</strong>
+            <br>
+            Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+          </p>
+        </div>
+      </div>
+      <div class="usa-banner-guidance-ssl usa-width-one-half">
+        <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/uswds/img/icon-https.svg" alt="SSL">
+        <div class="usa-media_block-body">
+          <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,51 @@
+    <header role="banner" class="usa-header usa-header-extended">
+      <a class="usa-skipnav" href="#main">Skip to Main Content</a>
+      {% include banner.html %}
+      <div class="usa-navbar">
+        <button class="usa-menu-btn">Menu</button>
+        <div class="usa-logo" id="logo">
+          <em class="usa-logo-text">
+            <a href="#" accesskey="1" title="Home" aria-label="Home" href="{{ site.baseurl }}/">{{ site.title }}</a>
+          </em>
+        </div>
+      </div>
+      <nav role="navigation" class="usa-nav">
+        <div class="usa-nav-inner">
+          <button class="usa-nav-close">
+            <img src="{{ site.baseurl }}/assets/uswds/img/close.svg" alt="close">
+          </button>
+
+          {% assign primary_links = site.header_nav.links %}
+          {% if primary_links %}
+          <ul class="usa-nav-primary usa-accordion">
+            {% for _section in primary_links %}
+            <li>
+              {# logic for accordions should go here in an if/else #}
+              <a class="usa-nav-link" href="{{ _section.href | relative_url }}">
+                <span>{{ _section.text }}</span>
+              </a>
+            </li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+
+          <div class="usa-nav-secondary">
+            <ul class="usa-unstyled-list usa-nav-secondary-links">
+              {% if site.jekyll_pages_api_search %}
+              <li>
+              <div role="search" class="usa-search usa-search-small">
+                {% jekyll_pages_api_search_interface %}
+              </div>
+              </li>
+            {% endif %}
+              {% if site.back_link %}
+              <li>
+                <a href="{{ site.back_link.url }}">{{ site.back_link.text }}</a>
+              </li>
+              {% endif %}
+            </ul>
+          </div>
+
+        </div>
+      </nav>
+    </header>

--- a/_includes/loop-nav.html
+++ b/_includes/loop-nav.html
@@ -1,15 +1,20 @@
 {% for node in include.chapters %}
 {% assign chapter = site.chapters | where: 'slug', node.id | first %}
 {% if chapter.enabled == false %}{% continue %}{% endif %}
-<li class="group">
-  <a href="#{{ chapter.slug }}">{{ chapter.title }}</a>
   {% if node.children %}
-    <button class="expand-subnav"
+  <li class="usa-accordion">
+    <button class="usa-accordion-button"
       aria-expanded="false"
-      aria-controls="nav-collapsible-{{ chapter.slug }}">+</button>
-    <ol class="nav-children" id="nav-collapsible-{{ chapter.slug }}" aria-hidden="true">
+      aria-controls="nav-collapsible-{{ chapter.slug }}">
+        {{ chapter.title }}
+      </button>
+    <ol class="nav-children usa-accordion-content" id="nav-collapsible-{{ chapter.slug }}" aria-hidden="true">
       {% include loop-nav.html chapters=node.children %}
     </ol>
+  </li>
+  {% else %}
+  <li>
+    <a href="#{{ chapter.slug }}">{{ chapter.title }}</a>
+  </li>
   {% endif %}
-</li>
 {% endfor %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,0 +1,10 @@
+<aside class="usa-width-one-third usa-layout-docs-sidenav js-sticky">
+    {% if site.intro %}
+    <p class="intro">{{ site.introduction }}</p>
+    {% endif %}
+    <nav role="navigation">
+      <ol data-gumshoe class="usa-sidenav-list">
+        {% include loop-nav.html chapters=site.data.chapters %}
+      </ol>
+    </nav>
+</aside>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>{{ site.title }}</title>
+    <link rel="stylesheet" href="{% guides_style_18f_asset_root %}/assets/uswds/css/uswds.min.css">
+    <link rel="stylesheet" href="{% guides_style_18f_asset_root %}/assets/css/main.css">
     <link rel="stylesheet" href="{% guides_style_18f_asset_root %}/assets/css/styles.css">
   </head>
   <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,36 +9,16 @@
   </head>
   <body>
     <div class="container">
-      <a class="skip-link visuallyhidden focusable" href="#main">Skip to Main Content</a>
+    {% include header.html %}
 
-      <header role="banner">
-        <div class="wrap">
-          <h1 class="site-title">
-            {{ site.title }}
-          </h1>
+      <div class="usa-grid">
 
-          <div class="back-link"><a href="https://pages.18f.gov/guides/">&laquo; Read more 18F Guides</a></div>
-        </div><!-- /.wrap -->
-      </header>
-
-      <div class="wrap content">
-
-        <main id="main" class="main-content">
+        {% include sidebar.html %}
+        <main id="main" class="usa-width-two-thirds usa-layout-docs-main_content" role="main">
           {{ content }}
         </main>
 
-        <aside>
-          {% if site.intro %}
-          <p class="intro">{{ site.introduction }}</p>
-          {% endif %}
-          <nav class="sidebar-nav js-sticky" role="navigation">
-            <ol>
-              {% include loop-nav.html chapters=site.data.chapters %}
-            </ol>
-          </nav>
-        </aside>
-
-      </div><!-- /.wrap.content -->
+      </div><!-- /.usa-grid -->
 
     </div><!-- /.container -->
   </body>

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,12 +1,13 @@
 ---
 ---
-
-@import "guides_style_18f";
+/*@import "guides_style_18f";*/
 
 @mixin font-size($sizeValue: 1.6) {
   font-size: ($sizeValue * 10) + px;
   font-size: $sizeValue + rem;
 }
+
+$wds-blue: #0071bc;
 
 html {
   font-size: 10px;
@@ -59,15 +60,15 @@ h6,
 nav a[aria-active=true]:link {
   background: transparent;
   // XXX this isn't turning links black for me...
-  color: #000;
-  font-weight: bold;
+  /*color: #000;*/
+  /*font-weight: bold;*/
 }
 
 // add the nav active indicator to targeted section titles
 section:target > h1,
 h2:target,
 h3:target {
-  border-left: 4px solid #1188ff;
+  border-left: 4px solid $wds-blue;
   padding-left: 10px;
 }
 
@@ -189,4 +190,41 @@ nav .group {
     position: sticky;
     top: 0;
   }
+}
+
+
+/**********************************
+ * SIDENAV ACCORDION WDS OVERRIDES*
+ **********************************/
+.usa-sidenav-list {
+  .usa-accordion-button {
+    background-color: initial;
+    padding: 0.85rem 1rem 0.85rem 1.8rem;
+    &:focus {
+      box-shadow: none;
+    }
+    &:hover {
+      background-color: #f1f1f1;
+    }
+  }
+  a {
+    &.active {
+      border-left: 4px solid $wds-blue;
+      color: $wds-blue;
+      font-weight: 700;
+      padding-left: 1.4rem;
+    }
+    &:focus {
+      box-shadow: none;
+    }
+  }
+
+  ol {
+    list-style: none;
+    padding: 0;
+  }
+}
+
+.usa-accordion+.usa-accordion {
+  margin-top: 0;
 }


### PR DESCRIPTION
This updates the guide to use the new release of the `guides-style` gem, which uses the WDS! 🎉 Here's a screenshot:
<img width="1124" alt="screen shot 2017-04-17 at 9 00 54 am" src="https://cloud.githubusercontent.com/assets/509309/25094567/a6039e6e-234c-11e7-90d1-2a9a2015bdf5.png">


There are, however, a couple of weird things going on here. Chief among them is that the `gumshoe` library that highlights the selected item on scroll seems to be having a hard time with the nested menus. The highlight in the nav is always one off from the selected section. I'd love some other eyes on this, because I can't find any rhyme or reason for it. (And it's new that it's consistent: previously, it would act correctly until the "Formatting" item in the nav and _then_ shift to being one off; E.g, "Formatting" would remain highlighted if you clicked "Units," "Units" would be highlighted if you clicked "Naming," etc.). Here's a screenshot:
<img width="1002" alt="screen shot 2017-04-17 at 9 01 32 am" src="https://cloud.githubusercontent.com/assets/509309/25094601/cd63d5c8-234c-11e7-9aff-3cc76383ac4e.png"> 

I also was hoping to get rid of some of the bespoke accordion JS in the repo, but removing it seems to break the accordions altogether, even though I'm using the WDS markup. Need to look into this more.