### PR TITLE
Remove references to pages.18f.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 This repo is where the 18F Frontend Guild keeps its guide (yep, I went there — guild and guide in one sentence) to best practices and resources for frontend development.
 
-#### Quicklinks to guides
-- Published guides: https://pages.18f.gov/frontend/
+#### Quicklinks
+- Published guides: https://frontend.18f.gov/
 - Unpublished guides: [pages](pages/)
 - Drafts: [pulls](https://github.com/18F/frontend/pulls?q=is%3Aopen+label%3Adraft+is%3Apr)
 
@@ -33,7 +33,7 @@ Also, the Frontend Guild Roadmap is in [the wiki](https://github.com/18F/fronten
 6. Label your pull request with `draft`.
 7. Post in #frontend slack channel for comment.
 
-If ready for publishing, you or someone else can move your guide to the 18f-pages branch so it appears on pages.18f.gov/frontend.
+If ready for publishing, you or someone else can move your guide to the 18f-pages branch so it appears on frontend.18f.gov.
 
 ### How to edit or suggest changes to an existing guide
 

--- a/_config.yml
+++ b/_config.yml
@@ -36,5 +36,5 @@ repos:
     url: https://github.com/18F/frontend
 
 back_link:
-  url: "https://pages.18f.gov/guides/"
+  url: "https://guides.18f.gov/"
   text: Read more 18F Guides

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
             {{ site.title }}
           </h1>
 
-          <div class="back-link"><a href="https://pages.18f.gov/guides/">&laquo; Read more 18F Guides</a></div>
+          <div class="back-link"><a href="https://guides.18f.gov">&laquo; Read more 18F Guides</a></div>
         </div><!-- /.wrap -->
       </header>
 


### PR DESCRIPTION
In compliance with the guidelines for migrating to Federalist fully and getting the ATO there, this removes all links that referenced `pages.18f.gov/frontend` and replaces them with `frontend.18f.gov`. It also changes references to `pages.18f.gov/guides` to the new `guides.18f/gov`.