### PR TITLE
Standardize JavaScript capitalization

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,7 +2,7 @@
 primary:
   - text: CSS
     href: /css/
-  - text: Javascript
+  - text: JavaScript
     href: /javascript/
   - text: Web Components
     href: /web-components/

--- a/pages/js/js.md
+++ b/pages/js/js.md
@@ -5,7 +5,7 @@ layout: docs
 sidenav: js
 ---
 
-# Javascript
-The purpose of the Javascript coding styleguide is to create and utilize
+# JavaScript
+The purpose of the JavaScript coding styleguide is to create and utilize
 consistent JS across 18F. The styleguide should be treated as a guide
 &mdash; rules can be modified according to project needs.


### PR DESCRIPTION
Closes #184 

I went with "JavaScript" since it was already more commonly used across the guide and it appears to be the official way to capitalize it.