### PR TITLE
Update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,23 @@
+## Building the guide locally
+The front end guide is built on the [USWDS Jekyll theme gem](https://github.com/18F/uswds-jekyll).
+
+To run it locally, clone this repo and then:
+1. Install [http://bundler.io/](Bundler) if you don't already have it: `gem install bundler`
+1. Run `bundle install`.
+1. Run `bundle exec jekyll serve`.
+
+## Submitting a pull request
+We welcome pull requests! Here's how to submit a PR:
+1. The guide publishes the `master` branch, so make sure you have the latest version of it.
+1. Create a new branch named in a way that describes your changes, optionally prefixed with your initials. Example: Heather Billings wants to create a PR that adds guidance around atomic CSS. She calls her branch `hjb-add-atomic-css`.
+1. Push your branch and open a work-in-progress (WIP) PR as soon as you have commits, rather than waiting until you feel you are finished. **A WIP PR includes `[WIP]` in the title and contains a list of unfinished tasks.** WIP PRs allow for early feedback and help prevent wasted time. It also allows other guild members to pick up and work on pull requests that have been abandoned for whatever reason.
+1. When your PR is ready for review, remove `[WIP]` from the title. This lets us know it's game time!
+1. A PR must pass the automatic Federalist build check in order to be merged into master.
+1. A PR must have one `approved` review in order to be merged into master. Any guild member with write access should be able to approve and merge PRs. (You cannot approve your own PR, sorry!)
+
+## Submitting issues
+Don't have time to file a pull request, but want to flag something? [https://github.com/18F/frontend/issues](Open an issue) stating what you think we should add or change and why, and we'll discuss it as a group.
+
 ## Public domain
 
 This project is in the public domain within the United States, and

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 
 This repo is where the 18F Front End Guild keeps its guide to best practices and resources for front end development.
 
-#### Quicklinks
+### Quicklinks
 
 - Guide: https://frontend.18f.gov/
+
+## Our mission
+We believe that government websites should be functional, maintainable, and thoughtfully designed. Our guild helps TTS promote the adoption and advancement of front end design and development best practices. In this way, TTS can lead by example while providing effective services that help our partners and customers fulfill their missions.
+To achieve our vision, the Front End Guild works to:
+- Support the continuous learning necessary for successful front-end work.
+- Provide TTS developers with easy-to-understand, actionable guidance around front-end best practices.
+- Promote a central knowledge base of shared tools and common patterns.
+- Create a healthy and supportive internal environment so that we can, in turn, bolster healthy external communities related to our work.
 
 ## How to track what we're doing, and how you can be involved!
 
@@ -21,4 +29,3 @@ The front end space is rapidly changing, and our guide is a living document. Ple
 3. Once a relatively clear and stable version emerges, an alert is posted to #dev, #g-frontend and #design for more review and comment.
 4. Once comments are resolved, the guidelines are posted publicly (location dependent on content).
 5. The new guidelines are announced to TTS via #news and email.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Front End Guild
 
-18F promotes team best practices across speciality areas through guilds. These guilds support their members in whatever way deemed most appropriate by those members themselves. [This branch](https://github.com/18F/frontend/tree/research) houses guild research into its membership needs.
+18F promotes team best practices across speciality areas through guilds. These guilds support their members in whatever way deemed most appropriate by those members themselves.
 
 This repo is where the 18F Front End Guild keeps its guide to best practices and resources for front end development.
 
@@ -10,16 +10,15 @@ This repo is where the 18F Front End Guild keeps its guide to best practices and
 
 ## How to track what we're doing, and how you can be involved!
 
-We use issues in this repo to track work.
+We use issues in this repo to track work. If you'd like to suggest a new topic or flag an issue
+
+The front end space is rapidly changing, and our guide is a living document. Please suggest edits or changes via pull request.
 
 ### How Guild best practices are developed
 
 1. Team members suggest needs in issues, and guild leads identify issues through [research](https://github.com/18F/frontend/tree/research).
 2. If resolving these issues requires documentation, a draft document is created in an internal Google Doc that is open to comment and announced to #g-frontend for contribution. NB: You can see all in-process docs in [this internal folder](https://drive.google.com/drive/u/1/#folders/0B84F26FpUP0lR1B2VVNGSi1MMVk/0B0C6PKlzps2JV3pqX3NJdm5WejA/0B5HeQa_YQ6-VTTlkVEFNZ2VWZEU/0B2CjDILjK8_jfmp1c2ZJM2d0eEtGSHFEeS1CenlHWEQ0S01jcWJfZXNObElUQV9Yei0wZ2s).
 3. Once a relatively clear and stable version emerges, an alert is posted to #dev, #g-frontend and #design for more review and comment.
-4. Once comments are resolved, the guide is posted publicly (location dependent on content).
-5. The best practice or guide is announced to TTS via #news and email.
+4. Once comments are resolved, the guidelines are posted publicly (location dependent on content).
+5. The new guidelines are announced to TTS via #news and email.
 
-### How to edit or suggest changes to an existing guide
-
-The front end space is rapidly changing and all our guides are living documents. Please suggest edits or changes via pull request.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,3 @@ To achieve our vision, the Front End Guild works to:
 We use issues in this repo to track work. If you'd like to suggest a new topic or flag an issue
 
 The front end space is rapidly changing, and our guide is a living document. Please suggest edits or changes via pull request.
-
-### How Guild best practices are developed
-
-1. Team members suggest needs in issues, and guild leads identify issues through [research](https://github.com/18F/frontend/tree/research).
-2. If resolving these issues requires documentation, a draft document is created in an internal Google Doc that is open to comment and announced to #g-frontend for contribution. NB: You can see all in-process docs in [this internal folder](https://drive.google.com/drive/u/1/#folders/0B84F26FpUP0lR1B2VVNGSi1MMVk/0B0C6PKlzps2JV3pqX3NJdm5WejA/0B5HeQa_YQ6-VTTlkVEFNZ2VWZEU/0B2CjDILjK8_jfmp1c2ZJM2d0eEtGSHFEeS1CenlHWEQ0S01jcWJfZXNObElUQV9Yei0wZ2s).
-3. Once a relatively clear and stable version emerges, an alert is posted to #dev, #g-frontend and #design for more review and comment.
-4. Once comments are resolved, the guidelines are posted publicly (location dependent on content).
-5. The new guidelines are announced to TTS via #news and email.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Front End Guild
 
-18F promotes team best practices across speciality areas through guilds. These guilds support their members in whatever way deemed most appropriate by those members themselves.
+18F promotes team best practices across specialty areas through guilds. These guilds support their members in whatever way deemed most appropriate by those members themselves.
 
 This repo is where the 18F Front End Guild keeps its guide to best practices and resources for front end development.
 
@@ -11,13 +11,13 @@ This repo is where the 18F Front End Guild keeps its guide to best practices and
 ## Our mission
 We believe that government websites should be functional, maintainable, and thoughtfully designed. Our guild helps TTS promote the adoption and advancement of front end design and development best practices. In this way, TTS can lead by example while providing effective services that help our partners and customers fulfill their missions.
 To achieve our vision, the Front End Guild works to:
-- Support the continuous learning necessary for successful front-end work.
-- Provide TTS developers with easy-to-understand, actionable guidance around front-end best practices.
+- Support the continuous learning necessary for successful front end work.
+- Provide TTS developers with easy-to-understand, actionable guidance around front end best practices.
 - Promote a central knowledge base of shared tools and common patterns.
 - Create a healthy and supportive internal environment so that we can, in turn, bolster healthy external communities related to our work.
 
 ## How to track what we're doing, and how you can be involved!
 
-We use issues in this repo to track work. If you'd like to suggest a new topic or flag an issue
+We use issues in this repo to track work. If you'd like to suggest a new topic or flag an issue, please [file an issue](https://github.com/18F/frontend/issues/new/).
 
 The front end space is rapidly changing, and our guide is a living document. Please suggest edits or changes via pull request.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,25 @@
-## 18F Front End Guild
+## Front End Guild
 
-18F is promoting team best practices across speciality areas through guilds. These guilds support their members in whatever way deemed most appropriate by those members themselves. [This branch](https://github.com/18F/frontend/tree/research) houses guild research into its membership needs.
+18F promotes team best practices across speciality areas through guilds. These guilds support their members in whatever way deemed most appropriate by those members themselves. [This branch](https://github.com/18F/frontend/tree/research) houses guild research into its membership needs.
 
-This repo is where the 18F Frontend Guild keeps its guide (yep, I went there — guild and guide in one sentence) to best practices and resources for frontend development.
+This repo is where the 18F Front End Guild keeps its guide to best practices and resources for front end development.
 
 #### Quicklinks
-- Published guides: https://frontend.18f.gov/
-- Unpublished guides: [pages](pages/)
-- Drafts: [pulls](https://github.com/18F/frontend/pulls?q=is%3Aopen+label%3Adraft+is%3Apr)
+
+- Guide: https://frontend.18f.gov/
 
 ## How to track what we're doing, and how you can be involved!
 
-We use issues in this repo to track work. They are accessible in a nice visual, prioritized form on [our waffle board](https://waffle.io/18F/frontend).
-
-Also, the Frontend Guild Roadmap is in [the wiki](https://github.com/18F/frontend/wiki), and research into what the guild should be doing to support frontend practice at 18F is kept in [this branch](https://github.com/18F/frontend/tree/research).
+We use issues in this repo to track work.
 
 ### How Guild best practices are developed
 
 1. Team members suggest needs in issues, and guild leads identify issues through [research](https://github.com/18F/frontend/tree/research).
-2. If resolving these issues requires documentation, a draft document is created in an internal Google Doc that is open to comment and announced to #frontend for contribution. NB: You can see all in-process docs in [this internal folder](https://drive.google.com/drive/u/1/#folders/0B84F26FpUP0lR1B2VVNGSi1MMVk/0B0C6PKlzps2JV3pqX3NJdm5WejA/0B5HeQa_YQ6-VTTlkVEFNZ2VWZEU/0B2CjDILjK8_jfmp1c2ZJM2d0eEtGSHFEeS1CenlHWEQ0S01jcWJfZXNObElUQV9Yei0wZ2s).
-3. Once a relatively clear and stable version emerges, an alert is posted to #dev, #frontend and #design for more review and comment.
+2. If resolving these issues requires documentation, a draft document is created in an internal Google Doc that is open to comment and announced to #g-frontend for contribution. NB: You can see all in-process docs in [this internal folder](https://drive.google.com/drive/u/1/#folders/0B84F26FpUP0lR1B2VVNGSi1MMVk/0B0C6PKlzps2JV3pqX3NJdm5WejA/0B5HeQa_YQ6-VTTlkVEFNZ2VWZEU/0B2CjDILjK8_jfmp1c2ZJM2d0eEtGSHFEeS1CenlHWEQ0S01jcWJfZXNObElUQV9Yei0wZ2s).
+3. Once a relatively clear and stable version emerges, an alert is posted to #dev, #g-frontend and #design for more review and comment.
 4. Once comments are resolved, the guide is posted publicly (location dependent on content).
-5. The best practice or guide is announced to the entire 18F Team via #news and email.
-
-### How to create a new guide
-
-1. Fork or clone the frontend repo. `git clone git@github.com:18F/frontend.git`
-2. Create a new branch for your guide, prefixed with `draft-`. `git checkout -b draft-a_new_guide`
-3. Create a markdown(md) file in the pages directory for your guide. `touch pages/draft-a_new_guide.md`
-4. After editing add, commit and push changes. `git add pages && git commit && git push origin draft-a_new_guide`
-5. Create a pull request on github.
-6. Label your pull request with `draft`.
-7. Post in #frontend slack channel for comment.
-
-If ready for publishing, you or someone else can move your guide to the 18f-pages branch so it appears on frontend.18f.gov.
+5. The best practice or guide is announced to TTS via #news and email.
 
 ### How to edit or suggest changes to an existing guide
 
-The frontend space is rapidly changing and all our guides are living documents. Once they are published as guides on 18F Guides, please suggest edits or changes via pull request.
-
-### Public domain
-
-This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
-
-> This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
-
-> All contributions to this project will be released under the CC0
->dedication. By submitting a pull request, you are agreeing to comply
->with this waiver of copyright interest.
+The front end space is rapidly changing and all our guides are living documents. Please suggest edits or changes via pull request.


### PR DESCRIPTION
Our `CONTRIBUTING` and `README` are horribly out of date. Update them.
### Contributing
- [x] Add instructions about how to build the guide locally
- [x] Add guidelines for submitting a PR

### README
- [x] Remove outdate information and links
- [x] Add new mission statement
- [x] Add information about how to get involved with or reach out to the guild
- [ ] Add new process information
- [ ] Decide whether we still want to use things like the wiki