### PR TITLE
Fix security related URLs

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -48,3 +48,7 @@ js:
     href: /javascript/libraries/
   - text: Style / Linting
     href: /javascript/style/
+
+security:
+  - text: Content Security Policy (CSP)
+    href: /security/content-security-policy/

--- a/pages/security/csp.md
+++ b/pages/security/csp.md
@@ -1,6 +1,6 @@
 ---
 title: Content Security Policy
-permalink: /security/content-security-policy
+permalink: /security/content-security-policy/
 layout: docs
 sidenav: security
 ---

--- a/pages/security/index.md
+++ b/pages/security/index.md
@@ -1,0 +1,10 @@
+---
+title: Security 
+permalink: /security/
+layout: docs
+sidenav: security 
+---
+
+# Security 
+
+Security is everybody's responsibility at 18F. There are practices that we should adhere to as much as possible when building websites and this guide contains the ones that front end designers and developers need to be aware of.


### PR DESCRIPTION
The permalink was missing the trailing slash for the CSP page which resulted in the URL having a .html file extension, while the rest of the documents do not. I updated the permalink to account for this and added both a security main page as well as data for the security side navigation.