### PR TITLE
Update to correct usage of front end and front-end

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## Building the guide locally
-The front end guide is built on the [USWDS Jekyll theme gem](https://github.com/18F/uswds-jekyll).
+The front-end guide is built on the [USWDS Jekyll theme gem](https://github.com/18F/uswds-jekyll).
 
 To run it locally, clone this repo and then:
 1. Install [http://bundler.io/](Bundler) if you don't already have it: `gem install bundler`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## Building the guide locally
-The front-end guide is built on the [USWDS Jekyll theme gem](https://github.com/18F/uswds-jekyll).
+The Front-End Guide is built on the [USWDS Jekyll theme gem](https://github.com/18F/uswds-jekyll).
 
 To run it locally, clone this repo and then:
 1. Install [http://bundler.io/](Bundler) if you don't already have it: `gem install bundler`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Front-end Guild
+## Front-End Guild
 
 18F promotes team best practices across specialty areas through guilds. These guilds support their members in whatever way deemed most appropriate by those members themselves.
 
-This repo is where the 18F Front-end Guild keeps its guide to best practices and resources for front-end development.
+This repo is where the 18F Front-End Guild keeps its guide to best practices and resources for front-end development.
 
 ### Quicklinks
 
@@ -10,7 +10,7 @@ This repo is where the 18F Front-end Guild keeps its guide to best practices and
 
 ## Our mission
 We believe that government websites should be functional, maintainable, and thoughtfully designed. Our guild helps TTS promote the adoption and advancement of front-end design and development best practices. In this way, TTS can lead by example while providing effective services that help our partners and customers fulfill their missions.
-To achieve our vision, the Front-end Guild works to:
+To achieve our vision, the Front-End Guild works to:
 - Support the continuous learning necessary for successful front-end work.
 - Provide TTS developers with easy-to-understand, actionable guidance around front-end best practices.
 - Promote a central knowledge base of shared tools and common patterns.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-## Front End Guild
+## Front-end Guild
 
 18F promotes team best practices across specialty areas through guilds. These guilds support their members in whatever way deemed most appropriate by those members themselves.
 
-This repo is where the 18F Front End Guild keeps its guide to best practices and resources for front end development.
+This repo is where the 18F Front-end Guild keeps its guide to best practices and resources for front-end development.
 
 ### Quicklinks
 
 - Guide: https://frontend.18f.gov/
 
 ## Our mission
-We believe that government websites should be functional, maintainable, and thoughtfully designed. Our guild helps TTS promote the adoption and advancement of front end design and development best practices. In this way, TTS can lead by example while providing effective services that help our partners and customers fulfill their missions.
-To achieve our vision, the Front End Guild works to:
-- Support the continuous learning necessary for successful front end work.
-- Provide TTS developers with easy-to-understand, actionable guidance around front end best practices.
+We believe that government websites should be functional, maintainable, and thoughtfully designed. Our guild helps TTS promote the adoption and advancement of front-end design and development best practices. In this way, TTS can lead by example while providing effective services that help our partners and customers fulfill their missions.
+To achieve our vision, the Front-end Guild works to:
+- Support the continuous learning necessary for successful front-end work.
+- Provide TTS developers with easy-to-understand, actionable guidance around front-end best practices.
 - Promote a central knowledge base of shared tools and common patterns.
 - Create a healthy and supportive internal environment so that we can, in turn, bolster healthy external communities related to our work.
 
@@ -20,4 +20,4 @@ To achieve our vision, the Front End Guild works to:
 
 We use issues in this repo to track work. If you'd like to suggest a new topic or flag an issue, please [file an issue](https://github.com/18F/frontend/issues/new/).
 
-The front end space is rapidly changing, and our guide is a living document. Please suggest edits or changes via pull request.
+The front-end space is rapidly changing, and our guide is a living document. Please suggest edits or changes via pull request.

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: 18F Front-end Guide
+title: 18F Front-End Guide
 
 styles:
   - /assets/css/styles.css
@@ -38,7 +38,7 @@ logoalt: 18F logo
 google_analytics_ua: UA-48605964-19
 
 repo:
-  name: Front-end Guide
+  name: Front-End Guide
   description: Main repository
   url: https://github.com/18F/frontend
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: 18F Front End Guide
+title: 18F Front-end Guide
 
 styles:
   - /assets/css/styles.css
@@ -38,7 +38,7 @@ logoalt: 18F logo
 google_analytics_ua: UA-48605964-19
 
 repo:
-  name: Front End Guide
+  name: Front-end Guide
   description: Main repository
   url: https://github.com/18F/frontend
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -5,7 +5,7 @@ permalink: /
 Welcome to the 18F Front-End Guide! This is where we keep all of our
 guidelines for front-end design and development.
 
-## What is Front end?
+## What is front end?
 
 The Front-End Guild did a series of exercises to determine the
 fundamental differences between the front-end design and front-end

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,33 +1,33 @@
 ---
-title: 18F Front End Guide
+title: 18F Front-end Guide
 permalink: /
 ---
-Welcome to the 18F front end guide! This is where we keep all of our
-guidelines for front end design and development.
+Welcome to the 18F front-end guide! This is where we keep all of our
+guidelines for front-end design and development.
 
 ## What is Front end
 
-The front end guild did a series of exercises to determine the
-fundamental differences between the front end design and front end
+The front-end guild did a series of exercises to determine the
+fundamental differences between the front-end design and front-end
 developer roles at 18F. Using [some of our own research
-methods](https://methods.18f.gov), the front end guild came up with
+methods](https://methods.18f.gov), the front-end guild came up with
 the following recommendations on knowing the difference between the
 two disciplines:
 
-**Front end designers** design, write, and implement the
+**Front-end designers** design, write, and implement the
 presentational code base for websites and applications. They should
 have a clear understanding of design fundamentals and systems, such
-as interface style guides, responsive design, grid systems, front end
-frameworks, and accessibility best practices. Front end designers
+as interface style guides, responsive design, grid systems, front-end
+frameworks, and accessibility best practices. Front-end designers
 should feel comfortable creating and implementing design systems
 using semantic HTML5, CSS/Sass and be able to assist in debugging
 this aspect of the code base.
 
-**Front end developers** architect, write, and implement the
+**Front-end developers** architect, write, and implement the
 functional code base for websites and applications. They should have
 a clear understanding of client-side render and response, such as
 HTTP methods, API consumption, the browser loading/rendering
-pipeline, and accessibility best practices. Front end developers
+pipeline, and accessibility best practices. Front-end developers
 should feel comfortable developing and implementing client-side
 interactions and frameworks using semantic HTML5 and JavaScript, and
 should be able to help with debugging, testing, and performance

--- a/pages/index.md
+++ b/pages/index.md
@@ -5,7 +5,7 @@ permalink: /
 Welcome to the 18F Front-End Guide! This is where we keep all of our
 guidelines for front-end design and development.
 
-## What is Front end
+## What is Front end?
 
 The Front-End Guild did a series of exercises to determine the
 fundamental differences between the front-end design and front-end

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,16 +1,16 @@
 ---
-title: 18F Front-end Guide
+title: 18F Front-End Guide
 permalink: /
 ---
-Welcome to the 18F front-end guide! This is where we keep all of our
+Welcome to the 18F Front-End Guide! This is where we keep all of our
 guidelines for front-end design and development.
 
 ## What is Front end
 
-The front-end guild did a series of exercises to determine the
+The Front-End Guild did a series of exercises to determine the
 fundamental differences between the front-end design and front-end
 developer roles at 18F. Using [some of our own research
-methods](https://methods.18f.gov), the front-end guild came up with
+methods](https://methods.18f.gov), the Front-End Guild came up with
 the following recommendations on knowing the difference between the
 two disciplines:
 

--- a/pages/js/dependencies.md
+++ b/pages/js/dependencies.md
@@ -63,7 +63,7 @@ npm allows various hooks to be executed during the install process. These script
 - A package *should* be scoped to 18F if its use cases fall mainly inside of 18F.
   - Example: [@18f/stylelint-rules](https://github.com/18F/stylelint-rules) is scoped to 18f because it's an 18F specific linting configuration that's directly linked to the 18F guides site.
 - A package *should* be scoped to 18f to avoid naming conflicts.
-  - Example: If 18F made a generic front end accordion to use across 18F sites, it should probably be scoped to `@18f/accordion` to avoid conflicts with all other accordions out there.
+  - Example: If 18F made a generic front-end accordion to use across 18F sites, it should probably be scoped to `@18f/accordion` to avoid conflicts with all other accordions out there.
 
 ##### How to scope a package to 18F
 - Ensure you are part of the 18f npm org and have at least developer rights. This can be found on the [18f org team page](https://www.npmjs.com/org/18f/members).

--- a/pages/js/frameworks.md
+++ b/pages/js/frameworks.md
@@ -14,7 +14,7 @@ AngularJS (commonly referred to as "Angular") is an open-source web application 
   - complex data visualization dashboards
   - lazy-loaded from the back end
 - When the site's design specifies a single page app architecture over classic server request and response.
-- When the whole site will be built with Angular to maintain front end code consistency.
+- When the whole site will be built with Angular to maintain front-end code consistency.
 
 #### When not to use:
 - For a single or a few simple components (with the rest of the site not using Angular), instead see React or Web Components.
@@ -25,7 +25,7 @@ AngularJS (commonly referred to as "Angular") is an open-source web application 
 - When the long-term maintenance dev team is very unfamiliar with Angular and don't have the resources to learn or hire for it.
 
 #### Pros:
-- Takes care of a lot of boilerplate code for front end interactions.
+- Takes care of a lot of boilerplate code for front-end interactions.
 - Attempts to extend HTML itself, and was designed so less experienced devs could use it.
 - Being maintained and developed by Google generally means good support.
 
@@ -41,7 +41,7 @@ Backbone.js is a JavaScript library with a RESTful JSON interface and is based o
 
 #### When to use:
 - A page design that requires dynamic data manipulation on the front end without a server request response, such as a todo app.
-- When a small front end framework is required due to performance constraints.
+- When a small front-end framework is required due to performance constraints.
 - When the long-term dev maintenance team is unfamiliar with any full frameworks, such as Angular.
 - To use as a wrapper and rest data manipulation library around a view-only framework, such as React.
 - When the dev team is familiar enough with Backbone to know how to write maintainable Backbone code.
@@ -71,7 +71,7 @@ React (sometimes styled React.js or ReactJS) is an open-source JavaScript librar
 - JavaScript UI that incorperates many nested components.
 - A UI with many components and updates that needs to be performance conscious.
 - When only a "view" framework is desired/required.
-- To ensure all front end components conform to a single standard.
+- To ensure all front-end components conform to a single standard.
 
 #### When not to use:
 - When a complex build process is not feasible. React requires transforming "jsx" files to regular JavaScript.

--- a/pages/security/index.md
+++ b/pages/security/index.md
@@ -6,4 +6,4 @@ sidenav: security
 
 # Security
 
-Security is everybody's responsibility at 18F. There are practices that we should adhere to as much as possible when building websites and this guide contains the ones that front end designers and developers need to be aware of.
+Security is everybody's responsibility at 18F. There are practices that we should adhere to as much as possible when building websites and this guide contains the ones that front-end designers and developers need to be aware of.


### PR DESCRIPTION
It's currently accepted that the following is the correct usage of front end and front-end:
>The term “front-end” is correct when used as a compound adjective, and the term “front end” is correct when used as a noun.

Source: https://css-tricks.com/poll-results-front-end-front-end/

This updates the repo to use this correct usage.

Preview: https://federalist-proxy.app.cloud.gov/preview/18f/frontend/update-front-end-name/